### PR TITLE
fix stand-alone validator - was using the 'rules' from the wrong scope

### DIFF
--- a/lib/validation/validator.rb
+++ b/lib/validation/validator.rb
@@ -53,8 +53,19 @@ module Validation
     # one error per field
     def valid?
       valid = true
+      all_rules = {}
 
-      rules.each_pair do |field, rules|
+      if self.instance_of?(Validation::Validator)
+        # use the normal instance variable
+        all_rules = self.rules
+
+      elsif self.is_a?(Validation::Validator) # inherited "stand-alone" validator
+        # in this case the rules have been defined in the class instance
+        # variable '@rules' since they were defined during the class definition
+        all_rules = self.class.rules
+      end
+
+      all_rules.each_pair do |field, rules|
         if ! @obj.respond_to?(field)
           raise InvalidKey
         end

--- a/spec/self_contained_validator_spec.rb
+++ b/spec/self_contained_validator_spec.rb
@@ -1,17 +1,39 @@
 require 'spec_helper'
 require 'validation'
 require 'validation/rule/not_empty'
+require 'validation/rule/email'
+require 'validation/rule/length'
 require 'ostruct'
 
 class SelfContainedValidator < Validation::Validator
   include Validation
 
-  rule :email, :not_empty
+  rule :test_mail, :email
+  rule :test_string, [:not_empty,
+                      :length => { :maximum => 5 }]
 end
 
 describe SelfContainedValidator do
-  it 'works like a validator' do
-    foo = SelfContainedValidator.new(OpenStruct.new(:email => 'foobar'))
-    foo.valid?.should be_true
+  let(:success_data) { OpenStruct.new(:test_mail => 'test@email.com', :test_string => 'test') }
+  let(:fail_data)    { OpenStruct.new(:test_mail => 'not an email', :test_string => '') }
+
+  context 'behaves like a validator' do
+    subject { SelfContainedValidator.new(success_data) }
+
+    it { should respond_to('valid?') }
+    it { should respond_to(:errors) }
   end
+
+  it 'passes validation for correct data' do
+    foo = SelfContainedValidator.new(success_data)
+    foo.should be_valid
+    foo.errors.should be_empty
+  end
+
+  it 'fails validation for wrong data' do
+    foo = SelfContainedValidator.new(fail_data)
+    foo.should_not be_valid
+    foo.errors.should include(:test_mail, :test_string)
+  end
+
 end


### PR DESCRIPTION
Hi!
I would love to use your gem in a little project of mine, which could become (at some point) part of [Diaspora*](https://github.com/diaspora/diaspora)... (do you release this gem under an official license?)
Anyway, I noticed the feature for self-contained validators as advertised in the Readme was not working correctly, and I hope to fix it with this pull request.

Let me know, if you need anything more for this to get merged ;)
