### PR TITLE
Allow self-contained validators to accept new rules

### DIFF
--- a/lib/validation/validator.rb
+++ b/lib/validation/validator.rb
@@ -53,19 +53,8 @@ module Validation
     # one error per field
     def valid?
       valid = true
-      all_rules = {}
 
-      if self.instance_of?(Validation::Validator)
-        # use the normal instance variable
-        all_rules = self.rules
-
-      elsif self.is_a?(Validation::Validator) # inherited "stand-alone" validator
-        # in this case the rules have been defined in the class instance
-        # variable '@rules' since they were defined during the class definition
-        all_rules = self.class.rules
-      end
-
-      all_rules.each_pair do |field, rules|
+      rules.each_pair do |field, rules|
         if ! @obj.respond_to?(field)
           raise InvalidKey
         end
@@ -120,6 +109,7 @@ module Validation
     include Validation::Rules
 
     def initialize(obj)
+      @rules = self.class.rules if self.class.is_a?(Validation::Rules)
       @obj = obj
     end
   end

--- a/spec/self_contained_validator_spec.rb
+++ b/spec/self_contained_validator_spec.rb
@@ -36,4 +36,19 @@ describe SelfContainedValidator do
     foo.errors.should include(:test_mail, :test_string)
   end
 
+  context 'when adding new rules' do
+    let(:data) { OpenStruct.new(:test_mail => 'test@email.com', :test_string => '') }
+    subject { SelfContainedValidator.new(data) }
+    before { subject.rule(:test_mail, :length => { :maximum => 3}) }
+
+    it 'keeps the old rules' do
+      subject.should_not be_valid
+      subject.errors.should include(:test_string)
+    end
+
+    it 'validates both old and new rules' do
+      subject.should_not be_valid
+      subject.errors.should include(:test_mail)
+    end
+  end
 end


### PR DESCRIPTION
`Validation::Rules` looks only to the current instance, and `Validation::Validator` instances begin with the rules defined in the class.
