### PR TITLE
Include inner exception when raising InvalidRule

### DIFF
--- a/lib/validation/validator.rb
+++ b/lib/validation/validator.rb
@@ -44,7 +44,7 @@ module Validation
           rules[field] << rule
         end
       rescue NameError => e
-        raise InvalidRule
+        raise InvalidRule.new(e)
       end
     end
 

--- a/spec/validation/validator_spec.rb
+++ b/spec/validation/validator_spec.rb
@@ -102,6 +102,22 @@ describe Validation::Validator do
         lambda { subject.valid? }.should raise_error(Validation::InvalidKey)
       end
     end
+
+    context 'invalid rule' do
+      before :each do
+        rule = stub('rule', :valid_value? => false)
+      end
+
+      it 'raises a descriptive error if an invalid rule is attempted' do
+        actual_message = ""
+        begin
+          subject.rule(:foobar, :invalid_rule)
+        rescue Validation::InvalidRule => e
+          actual_message = e.message
+        end
+        actual_message.should == "uninitialized constant Validation::Rule::InvalidRule"
+      end
+    end
   end
 
   context :errors do


### PR DESCRIPTION
This makes debugging rule usage much easier, since the stack trace will now say something like `uninitialized constant Validation::Rule::TypoInRuleName`, instead of simply `InvalidRule`.
