### PR TITLE
Add a feature to describe the errors in English

### DIFF
--- a/lib/validation/validator.rb
+++ b/lib/validation/validator.rb
@@ -10,6 +10,11 @@ module Validation
       @errors ||= {}
     end
 
+    # A string representation of the errors for this object
+    def errors_described
+      return Rules.describe_errors(@errors)
+    end
+
     # Define a rule for this object
     #
     # The rule parameter can be one of the following:
@@ -89,7 +94,7 @@ module Validation
       errors.each do |field, violation|
         params = violation[:params]
         rule_description = violation[:rule].to_s
-        if params.length > 0
+        if !params.nil? && params.length > 0
           rule_description << " #{params.inspect}"
         end
         messages << "The value of '#{field}' failed the validation rule '#{rule_description}'."

--- a/spec/validation/validator_spec.rb
+++ b/spec/validation/validator_spec.rb
@@ -138,6 +138,24 @@ describe Validation::Validator do
     end
   end
 
+  context :errors_described do
+    subject { Validation::Validator.new(OpenStruct.new(:id => 1, :email => '', :foobar => '')) }
+
+    it "describes errors in English" do
+      not_empty = stub('not_empty', :valid_value? => false, :error_key => :not_empty, :params => nil)
+      Validation::Rule::NotEmpty.should_receive(:new).and_return(not_empty)
+      length = stub('length', :valid_value? => false, :error_key => :length, :params => nil)
+      Validation::Rule::Length.should_receive(:new).and_return(length)
+
+      subject.rule(:email, :not_empty)
+      subject.rule(:foobar, :length)
+      subject.valid?
+      subject.errors_described.should == 
+            "The value of 'email' failed the validation rule 'not_empty'.\n" +
+            "The value of 'foobar' failed the validation rule 'length'."
+    end
+  end
+
   context :describe_errors do
     
     it "can describe a validation error" do


### PR DESCRIPTION
As much fun as it would be to show the user
`{:email=>{:rule=>:not_empty, :params=>{}}}`, I think they will better appreciate this:
`The value of 'email' failed the validation rule 'not_empty'.`
