### PR TITLE
Add RegularExpression and simple spec

### DIFF
--- a/lib/validation/rule/regular_expression.rb
+++ b/lib/validation/rule/regular_expression.rb
@@ -1,0 +1,22 @@
+module Validation
+  module Rule
+    class RegularExpression
+
+      def initialize(params)
+        @params = params
+      end
+
+      def error_key
+        :regular_expression
+      end
+
+      def valid_value?(value)
+        value.nil? || !!@params[:regex].match(value)
+      end
+
+      def params
+        @params
+      end
+    end
+  end
+end

--- a/spec/validation/rule/regular_expression_spec.rb
+++ b/spec/validation/rule/regular_expression_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+require 'validation/rule/regular_expression'
+
+describe Validation::Rule::RegularExpression do
+  subject { Validation::Rule::RegularExpression }
+
+  it 'has an error key' do
+    subject.new('foo').error_key.should == :regular_expression
+  end
+
+  it 'returns its parameters' do
+    rule = subject.new(:regex => /\A.+\Z/)
+    rule.params.should == {:regex => /\A.+\Z/}
+  end
+
+  context :regex do
+    let(:rule) { subject.new(:regex => /\A[0-9]+\Z/) }
+    it 'is valid' do
+      rule.valid_value?('0123456789').should be_true
+    end
+
+    it 'is invalid' do
+      rule.valid_value?('a').should be_false
+      rule.valid_value?('2b').should be_false
+      rule.valid_value?('c3').should be_false
+    end
+  end
+end


### PR DESCRIPTION
It is now possible to use a rule that validates against a regular expression.

Sample usage:

```
require "validation"
require "validation/rule/regular_expression"

(...)
rule :zip_code, :regular_expression => {:regex => /\A[0-9]{5}(-[0-9]{4})?\Z/}
```

Notice that a `nil` will be considered valid, to allow a field to be optional.  A required field is what the `:not_empty` rule was invented for.
