### PR TITLE
allow nil in URI rule

### DIFF
--- a/lib/validation/rule/uri.rb
+++ b/lib/validation/rule/uri.rb
@@ -14,17 +14,17 @@ module Validation
       end
 
       def valid_value?(uri_string)
-        begin
-          uri = URI(uri_string)
-          @required_parts.each do |part|
-            if uri.send(part).nil? || uri.send(part).empty?
-              return false
-            end
+        return true if uri_string.nil?
+
+        uri = URI(uri_string)
+        @required_parts.each do |part|
+          if uri.send(part).nil? || uri.send(part).empty?
+            return false
           end
-          true
-        rescue ::URI::InvalidURIError => e
-          return false
         end
+        true
+      rescue ::URI::InvalidURIError
+        return false
       end
     end
   end

--- a/spec/validation/rule/uri_spec.rb
+++ b/spec/validation/rule/uri_spec.rb
@@ -16,6 +16,10 @@ describe Validation::Rule::URI do
     subject.params.should == {:required_elements => [:host]}
   end
 
+  it 'passes with nil' do
+    subject.valid_value?(nil).should be_true
+  end
+
   it 'fails when given an invalid uri' do
     subject.valid_value?('foo:/%urim').should be_false
   end


### PR DESCRIPTION
fixes the "ArgumentError: bad argument (expected URI object or URI string)"

with this you can make something like this: it can be nil, but if it is not nil, it must be a valid uri.

if it should not be nil, you can combine this with a not_empty rule