### PR TITLE
Add support for more uuid versions

### DIFF
--- a/lib/validation/rule/uuid.rb
+++ b/lib/validation/rule/uuid.rb
@@ -5,7 +5,9 @@ module Validation
       class UnknownVersion < StandardError; end
       # params can be any of the folowing:
       #
-      # - :version - v4 (only supports v4 at this time)
+      # - :version - v4
+      #              v5
+      #              uuid (Any valid uuid)
       #
       # Example:
       #
@@ -30,17 +32,16 @@ module Validation
 
       private
 
+      VERSION_REGEX = {
+        'uuid' => /^[0-9A-F]{8}-[0-9A-F]{4}-[1-5][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i,
+        'v4'   => /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i,
+        'v5'   => /^[0-9A-F]{8}-[0-9A-F]{4}-5[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i,
+      }
+
       def uuid_regex
-        if params[:version] == 'v4'
-          uuid_v4_regex
-        else
-          raise UnknownVersion
-        end
+        VERSION_REGEX.fetch(params[:version]) { raise UnknownVersion }
       end
 
-      def uuid_v4_regex
-        /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i
-      end
     end
   end
 end

--- a/spec/validation/rule/uuid_spec.rb
+++ b/spec/validation/rule/uuid_spec.rb
@@ -2,7 +2,7 @@ require 'ostruct'
 require 'validation/rule/uuid'
 
 describe Validation::Rule::Uuid do
-  params = { :version => 'v4' }
+  params = { :version => 'uuid' }
   subject { described_class.new(params) }
 
   it 'has params' do
@@ -15,6 +15,21 @@ describe Validation::Rule::Uuid do
 
   it 'passes when given a valid uuid' do
     subject.valid_value?("05369729-3e2d-4cc1-88ea-c7ad8665a5da").should be_true
+  end
+
+  it 'passes when given a valid v4 uuid' do
+    params = { :version => 'v4' }
+    subject.valid_value?("05369729-3e2d-4cc1-88ea-c7ad8665a5da").should be_true
+  end
+
+  it 'passes when given a valid v5 uuid' do
+    params = { :version => 'v5' }
+    subject.valid_value?("05369729-3e2d-5cc1-88ea-c7ad8665a5da").should be_true
+  end
+
+  it 'fails when version does not match' do
+    params = { :version => 'v4' }
+    subject.valid_value?("05369729-3e2d-5cc1-88ea-c7ad8665a5da").should be_false
   end
 
   it 'fails when given an invalid uuid' do
@@ -30,7 +45,7 @@ describe Validation::Rule::Uuid do
   end
 
   it 'fails when given an unknown uuid version' do
-    params = { :version => 'v5' }
+    params = { :version => 'v6' }
     subject.valid_value?("05369729-3e2d-4cc1-88ea-c7ad8665a5da").should be_false
   end
 end


### PR DESCRIPTION
This commit adds support for:

- v5 uuids with { version: 'v5' }
- any version with { verison: 'uuid' }