### PR TITLE
Allow passing in class objects for rules + Upgrade to RSpec 3.4 + Misc improvements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source 'https://rubygems.org'
 
 group :test do
   gem 'rake', '0.9.2.2'
-  gem 'rspec', '2.10.0'
+  gem 'rspec', '3.4.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,28 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.1.3)
+    diff-lcs (1.2.5)
     rake (0.9.2.2)
-    rspec (2.10.0)
-      rspec-core (~> 2.10.0)
-      rspec-expectations (~> 2.10.0)
-      rspec-mocks (~> 2.10.0)
-    rspec-core (2.10.1)
-    rspec-expectations (2.10.0)
-      diff-lcs (~> 1.1.3)
-    rspec-mocks (2.10.1)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.4)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   rake (= 0.9.2.2)
-  rspec (= 2.10.0)
+  rspec (= 3.4.0)
 
 BUNDLED WITH
-   1.10.6
+   1.12.5

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Validator is useful for validating the state of any existing ruby object.
 ```ruby
   object = OpenStruct.new(:email => 'foo@bar.com', :password => 'foobar')
   validator = Validation::Validator.new(object)
-  validator.rule(:email, [:email, :not_empty]) # multiple rules in one line
-  validator.rule(:password, :not_empty) # a single rule on a line
-  validator.rule(:password, :length => {:minimum => 3}) # a rule that takes parameters
+  validator.rule(:email, [:email, :not_empty])             # multiple rules in one line
+  validator.rule(:password, :not_empty)                    # a single rule on a line
+  validator.rule(:password, :length => { :minimum => 3 })  # a rule that takes parameters
 
   if validator.valid?
     # save the data somewhere
@@ -28,24 +28,20 @@ The first paramater can be any message that the object responds to.
 
 ### Writing your own rules
 
-If you have a custom rule you need to write, just put it inside the `Validation::Rule` namespace:
+If you have a custom rule you need to write, you can create a custom rule class for it:
 
 ```ruby
-  module Validation
-    module Rule
-      class MyCustomRule
-        def error_key
-          :my_custom_rule
-        end
+  class MyCustomRule
+    def error_key
+      :my_custom_rule
+    end
 
-        def valid_value?(value)
-          # Logic for determining the validity of the value
-        end
+    def valid_value?(value)
+      # Logic for determining the validity of the value
+    end
 
-        def params
-          {}
-        end
-      end
+    def params
+      {}
     end
   end
 ```
@@ -55,6 +51,20 @@ A rule class should have the following methods on it:
   - `error_key` a symbol to represent the error. This shows up in the errors hash.  Must be an underscored_version of the class name
   - `valid_value?(value)` the beef of the rule. This is where you determine if the value is valid or not
   - `params` the params hash that was passed into the constructor
+
+If you add your custom rule class to the `Validation::Rule` namespace, you can reference it using a symbol:
+
+```ruby
+  validator.rule(:field, :my_custom_rule)  # resolves to Validation::Rule::MyCustomRule
+  validator.rule(:field, :my_custom_rule => { :param => :value })
+```
+
+Otherwise, just pass in the rule class itself:
+
+```ruby
+  validator.rule(:field, MyProject::CustomRule)
+  validator.rule(:field, MyProject::CustomRule => { :param => :value })
+```
 
 ### Writing self-contained validators
 

--- a/lib/validation/version.rb
+++ b/lib/validation/version.rb
@@ -1,3 +1,3 @@
 module Validation
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end

--- a/spec/self_contained_validator_spec.rb
+++ b/spec/self_contained_validator_spec.rb
@@ -20,20 +20,20 @@ describe SelfContainedValidator do
   context 'behaves like a validator' do
     subject { SelfContainedValidator.new(success_data) }
 
-    it { should respond_to('valid?') }
-    it { should respond_to(:errors) }
+    it { is_expected.to respond_to('valid?') }
+    it { is_expected.to respond_to(:errors) }
   end
 
   it 'passes validation for correct data' do
     foo = SelfContainedValidator.new(success_data)
-    foo.should be_valid
-    foo.errors.should be_empty
+    expect(foo).to be_valid
+    expect(foo.errors).to be_empty
   end
 
   it 'fails validation for wrong data' do
     foo = SelfContainedValidator.new(fail_data)
-    foo.should_not be_valid
-    foo.errors.should include(:test_mail, :test_string)
+    expect(foo).not_to be_valid
+    expect(foo.errors).to include(:test_mail, :test_string)
   end
 
   context 'when adding new rules' do
@@ -42,13 +42,13 @@ describe SelfContainedValidator do
     before { subject.rule(:test_mail, :length => { :maximum => 3}) }
 
     it 'keeps the old rules' do
-      subject.should_not be_valid
-      subject.errors.should include(:test_string)
+      expect(subject).not_to be_valid
+      expect(subject.errors).to include(:test_string)
     end
 
     it 'validates both old and new rules' do
-      subject.should_not be_valid
-      subject.errors.should include(:test_mail)
+      expect(subject).not_to be_valid
+      expect(subject.errors).to include(:test_mail)
     end
   end
 end

--- a/spec/validation/rule/email_spec.rb
+++ b/spec/validation/rule/email_spec.rb
@@ -3,20 +3,20 @@ require 'validation/rule/email'
 
 describe Validation::Rule::Email do
   it 'passes with a valid email' do
-    subject.valid_value?('foo@bar.com').should be_true
+    expect(subject.valid_value?('foo@bar.com')).to eq(true)
   end
 
   it 'fails with an invalid email' do
-    ['', nil].each do |value|
-      subject.valid_value?(value).should be_false
+    ['bad-email', '', nil].each do |value|
+      expect(subject.valid_value?(value)).to eq(false)
     end
   end
 
   it 'has an error key' do
-    subject.error_key.should == :email
+    expect(subject.error_key).to eq(:email)
   end
 
-  it 'returns it\'s parameters' do
-    subject.params.should == {}
+  it 'returns its parameters' do
+    expect(subject.params).to eq({})
   end
 end

--- a/spec/validation/rule/length_spec.rb
+++ b/spec/validation/rule/length_spec.rb
@@ -5,27 +5,27 @@ describe Validation::Rule::Length do
   subject { Validation::Rule::Length }
 
   it 'has an error key' do
-    subject.new('foo').error_key.should == :length
+    expect(subject.new('foo').error_key).to eq(:length)
   end
 
-  it 'returns it\'s parameters' do
+  it 'returns its parameters' do
     rule = subject.new(:minimum => 5)
-    rule.params.should == {:minimum => 5}
+    expect(rule.params).to eq(:minimum => 5)
   end
 
   context :minimum do
     let(:rule) { subject.new(:minimum => 5) }
 
     it 'does not allow nil' do
-      rule.valid_value?(nil).should be_false
+      expect(rule.valid_value?(nil)).to eq(false)
     end
 
     it 'is valid' do
-      rule.valid_value?('foobarbar').should be_true
+      expect(rule.valid_value?('foobarbar')).to eq(true)
     end
 
     it 'is invalid' do
-      rule.valid_value?('foo').should be_false
+      expect(rule.valid_value?('foo')).to eq(false)
     end
   end
 
@@ -33,15 +33,15 @@ describe Validation::Rule::Length do
     let(:rule) { subject.new(:maximum => 5) }
 
     it 'allows nil' do
-      rule.valid_value?(nil).should be_true
+      expect(rule.valid_value?(nil)).to eq(true)
     end
 
     it 'is valid' do
-      rule.valid_value?('foo').should be_true
+      expect(rule.valid_value?('foo')).to eq(true)
     end
 
     it 'is invalid' do
-      rule.valid_value?('foobarbar').should be_false
+      expect(rule.valid_value?('foobarbar')).to eq(false)
     end
   end
 
@@ -49,15 +49,15 @@ describe Validation::Rule::Length do
     let(:rule) { subject.new(:exact => 5) }
 
     it 'does not allow nil' do
-      rule.valid_value?(nil).should be_false
+      expect(rule.valid_value?(nil)).to eq(false)
     end
 
     it 'is valid' do
-      rule.valid_value?('fooba').should be_true
+      expect(rule.valid_value?('fooba')).to eq(true)
     end
 
     it 'is valid' do
-      rule.valid_value?('foobar').should be_false
+      expect(rule.valid_value?('foobar')).to eq(false)
     end
   end
 end

--- a/spec/validation/rule/matches_spec.rb
+++ b/spec/validation/rule/matches_spec.rb
@@ -8,25 +8,25 @@ describe Validation::Rule::Matches do
   subject { Validation::Rule::Matches.new(field) }
 
   it 'has an error key' do
-    subject.error_key.should == :matches
+    expect(subject.error_key).to eq(:matches)
   end
 
-  it 'returns it\'s parameters' do
-    subject.params.should == field
+  it 'returns its parameters' do
+    expect(subject.params).to eq(field)
   end
 
   it 'accepts a data object' do
-    subject.obj = obj
+    expect { subject.obj = obj }.not_to raise_error
   end
 
   it 'passes on valid data' do
     subject.obj = obj
-    subject.valid_value?('bar').should be_true
+    expect(subject.valid_value?('bar')).to eq(true)
   end
 
   it 'fails on invalid data' do
     subject.obj = obj
-    subject.valid_value?('foo').should be_false
+    expect(subject.valid_value?('foo')).to eq(false)
   end
 
 end

--- a/spec/validation/rule/not_empty_spec.rb
+++ b/spec/validation/rule/not_empty_spec.rb
@@ -2,20 +2,20 @@ require 'validation/rule/not_empty'
 
 describe Validation::Rule::NotEmpty do
   it 'passes when a value exists' do
-    subject.valid_value?('foo').should be_true
+    expect(subject.valid_value?('foo')).to eq(true)
   end
 
   it 'fails when a value does not exist' do
     ['', nil].each do |value|
-      subject.valid_value?(value).should be_false
+      expect(subject.valid_value?(value)).to eq(false)
     end
   end
 
   it 'has an error key' do
-    subject.error_key.should == :not_empty
+    expect(subject.error_key).to eq(:not_empty)
   end
 
-  it 'returns it\'s parameters' do
-    subject.params.should == {}
+  it 'returns its parameters' do
+    expect(subject.params).to eq({})
   end
 end

--- a/spec/validation/rule/numeric_spec.rb
+++ b/spec/validation/rule/numeric_spec.rb
@@ -3,20 +3,20 @@ require 'validation/rule/numeric'
 
 describe Validation::Rule::Numeric do
   it 'passes when a value is numeric' do
-    subject.valid_value?(10).should be_true
+    expect(subject.valid_value?(10)).to eq(true)
   end
 
   it 'fails when a value is not numeric' do
     ['', nil, 'foo', 10.5].each do |value|
-      subject.valid_value?(value).should be_false
+      expect(subject.valid_value?(value)).to eq(false)
     end
   end
 
   it 'has an error key' do
-    subject.error_key.should == :numeric
+    expect(subject.error_key).to eq(:numeric)
   end
 
-  it 'returns it\'s parameters' do
-    subject.params.should == {}
+  it 'returns its parameters' do
+    expect(subject.params).to eq({})
   end
 end

--- a/spec/validation/rule/phone_spec.rb
+++ b/spec/validation/rule/phone_spec.rb
@@ -5,11 +5,11 @@ describe Validation::Rule::Phone do
   subject { Validation::Rule::Phone }
 
   it 'has an error key' do
-    subject.new.error_key.should == :phone
+    expect(subject.new.error_key).to eq(:phone)
   end
 
   it 'defaults to america format' do
-    subject.new.params.should == {:format => :america}
+    expect(subject.new.params).to eq(:format => :america)
   end
 
   context :america do
@@ -19,7 +19,7 @@ describe Validation::Rule::Phone do
         '1234567890',
         '11234567890'
       ].each do |phone|
-        rule.valid_value?(phone).should be_true
+        expect(rule.valid_value?(phone)).to eq(true)
       end
     end
 
@@ -29,7 +29,7 @@ describe Validation::Rule::Phone do
         '123456789',
         '123456789012'
       ].each do |phone|
-        rule.valid_value?(phone).should be_false
+        expect(rule.valid_value?(phone)).to eq(false)
       end
     end
   end

--- a/spec/validation/rule/regular_expression_spec.rb
+++ b/spec/validation/rule/regular_expression_spec.rb
@@ -5,24 +5,25 @@ describe Validation::Rule::RegularExpression do
   subject { Validation::Rule::RegularExpression }
 
   it 'has an error key' do
-    subject.new('foo').error_key.should == :regular_expression
+    expect(subject.new('foo').error_key).to eq(:regular_expression)
   end
 
   it 'returns its parameters' do
     rule = subject.new(:regex => /\A.+\Z/)
-    rule.params.should == {:regex => /\A.+\Z/}
+    expect(rule.params).to eq(:regex => /\A.+\Z/)
   end
 
   context :regex do
     let(:rule) { subject.new(:regex => /\A[0-9]+\Z/) }
+
     it 'is valid' do
-      rule.valid_value?('0123456789').should be_true
+      expect(rule.valid_value?('0123456789')).to eq(true)
     end
 
     it 'is invalid' do
-      rule.valid_value?('a').should be_false
-      rule.valid_value?('2b').should be_false
-      rule.valid_value?('c3').should be_false
+      expect(rule.valid_value?('a')).to eq(false)
+      expect(rule.valid_value?('2b')).to eq(false)
+      expect(rule.valid_value?('c3')).to eq(false)
     end
   end
 end

--- a/spec/validation/rule/uri_spec.rb
+++ b/spec/validation/rule/uri_spec.rb
@@ -5,33 +5,33 @@ describe Validation::Rule::URI do
   subject { described_class.new }
 
   it 'has an error key' do
-    subject.error_key.should == :uri
+    expect(subject.error_key).to eq(:uri)
   end
 
   it 'passes when given a valid uri' do
-    subject.valid_value?('http://uri.com').should be_true
+    expect(subject.valid_value?('http://uri.com')).to eq(true)
   end
 
   it 'has params' do
-    subject.params.should == {:required_elements => [:host]}
+    expect(subject.params).to eq(:required_elements => [:host])
   end
 
   it 'passes with nil' do
-    subject.valid_value?(nil).should be_true
+    expect(subject.valid_value?(nil)).to eq(true)
   end
 
   it 'fails when given an invalid uri' do
-    subject.valid_value?('foo:/%urim').should be_false
+    expect(subject.valid_value?('foo:/%urim')).to eq(false)
   end
 
   context "part validation" do
     it 'fails to validate when given a uri without a host' do
-      subject.valid_value?('http:foo@').should be_false
+      expect(subject.valid_value?('http:foo@')).to eq(false)
     end
 
     it 'fails to validate when given a uri without a scheme' do
       described_class.new([:host, :scheme])
-      subject.valid_value?('foo.com').should be_false
+      expect(subject.valid_value?('foo.com')).to eq(false)
     end
   end
 end

--- a/spec/validation/rule/uuid_spec.rb
+++ b/spec/validation/rule/uuid_spec.rb
@@ -6,46 +6,46 @@ describe Validation::Rule::Uuid do
   subject { described_class.new(params) }
 
   it 'has params' do
-    subject.params.should == params
+    expect(subject.params).to eq(params)
   end
 
   it 'has an error key' do
-    subject.error_key.should == :uuid
+    expect(subject.error_key).to eq(:uuid)
   end
 
   it 'passes when given a valid uuid' do
-    subject.valid_value?("05369729-3e2d-4cc1-88ea-c7ad8665a5da").should be_true
+    expect(subject.valid_value?("05369729-3e2d-4cc1-88ea-c7ad8665a5da")).to eq(true)
   end
 
   it 'passes when given a valid v4 uuid' do
     params = { :version => 'v4' }
-    subject.valid_value?("05369729-3e2d-4cc1-88ea-c7ad8665a5da").should be_true
+    expect(subject.valid_value?("05369729-3e2d-4cc1-88ea-c7ad8665a5da")).to eq(true)
   end
 
   it 'passes when given a valid v5 uuid' do
     params = { :version => 'v5' }
-    subject.valid_value?("05369729-3e2d-5cc1-88ea-c7ad8665a5da").should be_true
+    expect(subject.valid_value?("05369729-3e2d-5cc1-88ea-c7ad8665a5da")).to eq(true)
   end
 
   it 'fails when version does not match' do
     params = { :version => 'v4' }
-    subject.valid_value?("05369729-3e2d-5cc1-88ea-c7ad8665a5da").should be_false
+    expect(subject.valid_value?("05369729-3e2d-5cc1-88ea-c7ad8665a5da")).to eq(false)
   end
 
   it 'fails when given an invalid uuid' do
-    subject.valid_value?('not-a-uuid').should be_false
+    expect(subject.valid_value?('not-a-uuid')).to eq(false)
   end
 
   it 'fails when given a blank string' do
-    subject.valid_value?('').should be_false
+    expect(subject.valid_value?('')).to eq(false)
   end
 
   it 'fails when given a non-string' do
-    subject.valid_value?(5).should be_false
+    expect(subject.valid_value?(5)).to eq(false)
   end
 
   it 'fails when given an unknown uuid version' do
     params = { :version => 'v6' }
-    subject.valid_value?("05369729-3e2d-4cc1-88ea-c7ad8665a5da").should be_false
+    expect(subject.valid_value?("05369729-3e2d-4cc1-88ea-c7ad8665a5da")).to eq(false)
   end
 end

--- a/spec/validation/validator_spec.rb
+++ b/spec/validation/validator_spec.rb
@@ -39,10 +39,19 @@ describe Validation::Validator do
       ).to eq([not_empty_class, length_class])
     end
 
-    it 'accepts rules with parameters' do
+    it 'accepts rules with name + parameters' do
       rule = double
       expect(Validation::Rule::Length).to receive(:new).with({:maximum => 5, :minimum => 3}).and_return(rule)
       subject.rule(:email, :length => {:maximum => 5, :minimum => 3})
+
+      expect(subject.instance_variable_get(:@rules)[:email]).to eq([rule])
+    end
+
+    it 'accepts rules with class + parameters' do
+      rule_class = Class.new
+      rule = double
+      expect(rule_class).to receive(:new).with({:maximum => 5, :minimum => 3}).and_return(rule)
+      subject.rule(:email, rule_class => {:maximum => 5, :minimum => 3})
 
       expect(subject.instance_variable_get(:@rules)[:email]).to eq([rule])
     end


### PR DESCRIPTION
New feature allows passing in any rule class instead of requiring it to exist in `Validation::Rule`:

    validator.rule(:field, CustomValidatorClass => { param: :eters }

Also made the code a bit more DRY and upgraded the specs to RSpec 3 syntax.

Oh, and the `InvalidKey` exception now tells you which key is invalid.